### PR TITLE
add TransformBlock and DipoleBlock objects

### DIFF
--- a/peepingtom/core/__init__.py
+++ b/peepingtom/core/__init__.py
@@ -1,6 +1,6 @@
 from .alchemists import Alchemist, PointToLineAlchemist, PointToParticleAlchemist
 from .datablocks import DataBlock, GroupBlock, DataCrate, PointBlock, \
     LineBlock, OrientationBlock, ImageBlock, LineBlock, SphereBlock, PropertyBlock, \
-    ParticleBlock, MeshBlock
+    ParticleBlock, MeshBlock, DipoleBlock
 from .datablocks.base import DataCrate
 from .models import Model

--- a/peepingtom/core/__init__.py
+++ b/peepingtom/core/__init__.py
@@ -1,6 +1,6 @@
 from .alchemists import Alchemist, PointToLineAlchemist, PointToParticleAlchemist
 from .datablocks import DataBlock, GroupBlock, DataCrate, PointBlock, \
     LineBlock, OrientationBlock, ImageBlock, LineBlock, SphereBlock, PropertyBlock, \
-    ParticleBlock, MeshBlock, DipoleBlock
+    ParticleBlock, MeshBlock, DipoleBlock, TransformBlock
 from .datablocks.base import DataCrate
 from .models import Model

--- a/peepingtom/core/datablocks/__init__.py
+++ b/peepingtom/core/datablocks/__init__.py
@@ -7,3 +7,4 @@ from .particleblock import ParticleBlock
 from .pointblock import PointBlock
 from .propertyblock import PropertyBlock
 from .sphereblock import SphereBlock
+from .dipoleblock import DipoleBlock

--- a/peepingtom/core/datablocks/__init__.py
+++ b/peepingtom/core/datablocks/__init__.py
@@ -1,4 +1,5 @@
 from .base import DataBlock, GroupBlock, DataCrate
+from .dipoleblock import DipoleBlock
 from .imageblock import ImageBlock
 from .lineblock import LineBlock
 from .meshblock import MeshBlock
@@ -7,4 +8,4 @@ from .particleblock import ParticleBlock
 from .pointblock import PointBlock
 from .propertyblock import PropertyBlock
 from .sphereblock import SphereBlock
-from .dipoleblock import DipoleBlock
+from .transformblock import TransformBlock

--- a/peepingtom/core/datablocks/base.py
+++ b/peepingtom/core/datablocks/base.py
@@ -128,6 +128,13 @@ class GroupBlock(DataBlock, ABC):
     unites multiple DataBlocks to construct a complex data object
     """
     def __init__(self, children, parent=None):
+        """
+
+        Parameters
+        ----------
+        children :
+        parent
+        """
         super().__init__(parent=parent)
         self.children = children
 

--- a/peepingtom/core/datablocks/dipoleblock.py
+++ b/peepingtom/core/datablocks/dipoleblock.py
@@ -2,6 +2,7 @@ import numpy as np
 
 from .base import GroupBlock
 from .pointblock import PointBlock
+from .orientationblock import OrientationBlock
 from peepingtom.utils.helpers.linalg_helper import align_vectors
 
 
@@ -49,7 +50,7 @@ class DipoleBlock(GroupBlock):
         else:
             return True
 
-    def rotation_matrices(self, vector: np.ndarray):
+    def calculate_orientation_block(self, vector: np.ndarray):
         """
         Parameters
         -------
@@ -58,9 +59,9 @@ class DipoleBlock(GroupBlock):
 
         Returns
         -------
-        rotation_matrices : (n, 3, 3) set of rotation matrices
-                            Rotation matrices premultiply 'vector' to align it with the
-                            orientation vectors of each dipole in this object
+        orientation_block : OrientationBlock
+                            DataBlock containint rotation matrices which premultiply 'vector' to
+                            align it with the orientation vectors of each dipole in this object
         """
         # only implemented for 3d rotations
         if self.centers.data.shape[1] != 3:
@@ -74,5 +75,5 @@ class DipoleBlock(GroupBlock):
 
         # calculate rotation matrices
         rotation_matrices = align_vectors(normalised_vector, self.normalised_orientation_vectors)
-        return rotation_matrices
+        return OrientationBlock(rotation_matrices, parent=self)
 

--- a/peepingtom/core/datablocks/dipoleblock.py
+++ b/peepingtom/core/datablocks/dipoleblock.py
@@ -1,0 +1,78 @@
+import numpy as np
+
+from .base import GroupBlock
+from .pointblock import PointBlock
+from peepingtom.utils.helpers.linalg_helper import align_vectors
+
+
+class DipoleBlock(GroupBlock):
+    """
+    A DipoleBlock represents a set of n dipoles in an m-dimensional space
+    defined by center points and end points
+    """
+
+    def __init__(self, centers: PointBlock, endpoints: PointBlock):
+        # Set dipole info
+        self.centers = PointBlock(centers)
+        self.endpoints = PointBlock(endpoints)
+
+        # Check endpoint shape matches that of centers centers
+        self._check_shapes()
+
+        # Set blocks for GroupBlock
+        children = [centers, endpoints]
+        super().__init__(children)
+
+    def _data_setter(self, data):
+        self._data = data
+
+    @property
+    def orientation_vectors(self):
+        """
+        Vectors describing shifts to apply on centers to arrive at endpoints
+        """
+        return self.endpoints.data - self.centers.data
+
+    @property
+    def normalised_orientation_vectors(self):
+        """
+        self.orientation_vectors normalised to length 1
+        """
+        # Calculate length of each vector, add trailing dimension
+        norm = np.expand_dims(np.linalg.norm(self.orientation_vectors, axis=1), axis=-1)
+        # Calculate and return normalised vectors
+        return self.orientation_vectors / norm
+
+    def _check_shapes(self):
+        if self.centers.data.shape != self.endpoints.data.shape:
+            raise ValueError('Shapes of centers and endpoints do not match')
+        else:
+            return True
+
+    def rotation_matrices(self, vector: np.ndarray):
+        """
+        Parameters
+        -------
+        vector : np.ndarray
+                 A vector which you would like to align with the orientation vectors of each dipole
+
+        Returns
+        -------
+        rotation_matrices : (n, 3, 3) set of rotation matrices
+                            Rotation matrices premultiply 'vector' to align it with the
+                            orientation vectors of each dipole in this object
+        """
+        # only implemented for 3d rotations
+        if self.centers.data.shape[1] != 3:
+            raise NotImplementedError
+
+        # force ndarray
+        vector = np.asarray(vector).reshape(-1)
+
+        # normalise vector
+        normalised_vector = vector / np.linalg.norm(vector)
+
+        # calculate rotation matrices
+        rotation_matrices = align_vectors(normalised_vector, self.normalised_orientation_vectors)
+        return rotation_matrices
+

--- a/peepingtom/core/datablocks/orientationblock.py
+++ b/peepingtom/core/datablocks/orientationblock.py
@@ -131,7 +131,7 @@ class OrientationBlock(DataBlock):
 
     def dump(self):
         kwargs = super().dump()
-        kwargs.update({'rotation_matrices': self.data})
+        kwargs.update({'orientation_block': self.data})
         return kwargs
 
     @staticmethod

--- a/peepingtom/core/datablocks/transformblock.py
+++ b/peepingtom/core/datablocks/transformblock.py
@@ -1,6 +1,25 @@
-from .base import GroupBlock
+from .particleblock import ParticleBlock
 
-class TransformBlock(GroupBlock):
-    """
 
+class TransformBlock(ParticleBlock):
     """
+    A TransformBlock contains a set of 3D transforms described relative
+    to their own fixed coordinate system, made up of...
+    * positions : (n, 3) array of vectors describing shifts
+      to apply as (dx, dy, dz) relative to the origin (0, 0, 0)
+    * orientations : (n, 3, 3) array of rotation matrices to
+      rotation (by premultiplication) the unit vectors (i, j, k)
+    """
+    def apply_on(self, particles: ParticleBlock):
+        """
+        Applies the transforms encoded in this TransformBlock on a
+        set of particles in a ParticleBlock
+
+        Parameters
+        ----------
+        particles : ParticleBlock
+
+        Returns
+        -------
+
+        """

--- a/peepingtom/core/datablocks/transformblock.py
+++ b/peepingtom/core/datablocks/transformblock.py
@@ -7,8 +7,8 @@ class TransformBlock(ParticleBlock):
     to their own fixed coordinate system, made up of...
     * positions : (n, 3) array of vectors describing shifts
       to apply as (dx, dy, dz) relative to the origin (0, 0, 0)
-    * orientations : (n, 3, 3) array of rotation matrices to
-      rotation (by premultiplication) the unit vectors (i, j, k)
+    * orientations : (n, 3, 3) array of rotation matrices which
+      rotate (by premultiplication) the unit vectors (i, j, k)
     """
     def apply_on(self, particles: ParticleBlock):
         """
@@ -21,5 +21,8 @@ class TransformBlock(ParticleBlock):
 
         Returns
         -------
+        transformed_particles : ParticleBlock
+                                Shifted, rotated particles
 
         """
+        

--- a/peepingtom/core/datablocks/transformblock.py
+++ b/peepingtom/core/datablocks/transformblock.py
@@ -1,4 +1,8 @@
+import numpy as np
+
 from .particleblock import ParticleBlock
+from .pointblock import PointBlock
+from .orientationblock import OrientationBlock
 
 
 class TransformBlock(ParticleBlock):
@@ -10,10 +14,13 @@ class TransformBlock(ParticleBlock):
     * orientations : (n, 3, 3) array of rotation matrices which
       rotate (by premultiplication) the unit vectors (i, j, k)
     """
+
     def apply_on(self, particles: ParticleBlock):
         """
         Applies the transforms encoded in this TransformBlock on a
         set of particles in a ParticleBlock
+
+        For m transforms on n particles this results in m x n transformed particles
 
         Parameters
         ----------
@@ -25,4 +32,31 @@ class TransformBlock(ParticleBlock):
                                 Shifted, rotated particles
 
         """
-        
+        # set up necessary data, be explicit to avoid confusion
+        particle_positions = particles.positions.data.reshape(-1, 3, 1)  # (n, 3, 1) array
+        particle_orientations = particles.orientations  # (n, 3, 3) array of rotm
+        shift_vectors = self.positions.data.reshape(-1, 1, 3, 1)  # (m, 1, 3, 1) array
+        transform_orientations = self.orientations.data.reshape(-1, 1, 3, 3)  # (m, 1, 3, 3) array of rotm
+
+        n = particle_positions.shape[0]
+        m = shift_vectors.shape[0]
+
+        # Orient the shift vectors according to particle orientation
+        oriented_shifts = particle_orientations @ shift_vectors  # (m, n, 3, 1)
+
+        # Apply the transformed shifts onto the current particle positions
+        output_positions = particle_positions + oriented_shifts  # (m, n, 3, 1)
+
+        # Calculate the new orientations by composing rotations
+        #  (n, 3, 3) @ (m, 1, 3, 3) -> (m, n, 3, 3)
+        output_orientations = particle_orientations @ transform_orientations
+
+        # replace nan filled matrices with original particle orientations
+        # this happens when vectors are already aligned (causes div0)
+        output_orientations = np.where(np.isnan(output_orientations), particle_orientations, output_orientations)
+
+        # Create and return ParticleBlock from output
+        points = PointBlock(output_positions.reshape((-1, 3)))
+        orientations = OrientationBlock(output_orientations.reshape(-1, 3, 3))
+
+        return ParticleBlock(points, orientations, None)

--- a/tests/core/datablocks/test_dipoleblock.py
+++ b/tests/core/datablocks/test_dipoleblock.py
@@ -33,10 +33,9 @@ def test_dipoleblock_normalised_orientation_vector():
 def test_dipoleblock_rotation_matrices():
     block = DipoleBlock(test_centers, test_endpoints)
 
-
     # calculate rotation matrices to align test vector to each dipole in block
     vector_to_align = np.array([0, 2, 1]).reshape(1, 3, 1)
-    rotation_matrices = block.rotation_matrices(vector_to_align)
+    rotation_matrices = block.calculate_orientation_block(vector_to_align)
 
     # calculate vector to aligns new position after rotation by rotation_matrix
     aligned_vectors = rotation_matrices @ vector_to_align

--- a/tests/core/datablocks/test_dipoleblock.py
+++ b/tests/core/datablocks/test_dipoleblock.py
@@ -1,0 +1,50 @@
+import numpy as np
+from numpy.testing import assert_array_equal, assert_array_almost_equal
+
+from peepingtom.core import DipoleBlock
+
+test_centers = np.asarray([[0, 0, 0],
+                           [1, 1, 1],
+                           [2, 2, 2]])
+
+test_vectors = np.asarray([[0, 0, 1], [0, 0, 2], [3, 3, 3]])
+
+test_vector_norms = np.expand_dims(np.linalg.norm(test_vectors, axis=1), axis=-1)
+normalised_test_vectors = test_vectors / test_vector_norms
+
+test_endpoints = test_centers + test_vectors
+
+
+def test_dipoleblock_instantiation():
+    block = DipoleBlock(test_centers, test_endpoints)
+    assert isinstance(block, DipoleBlock)
+
+
+def test_dipoleblock_orientation_vectors():
+    block = DipoleBlock(test_centers, test_endpoints)
+    assert_array_equal(block.orientation_vectors, test_vectors)
+
+
+def test_dipoleblock_normalised_orientation_vector():
+    block = DipoleBlock(test_centers, test_endpoints)
+    assert_array_almost_equal(block.normalised_orientation_vectors, normalised_test_vectors)
+
+
+def test_dipoleblock_rotation_matrices():
+    block = DipoleBlock(test_centers, test_endpoints)
+
+
+    # calculate rotation matrices to align test vector to each dipole in block
+    vector_to_align = np.array([0, 2, 1]).reshape(1, 3, 1)
+    rotation_matrices = block.rotation_matrices(vector_to_align)
+
+    # calculate vector to aligns new position after rotation by rotation_matrix
+    aligned_vectors = rotation_matrices @ vector_to_align
+    aligned_vectors = aligned_vectors.reshape(-1, 3)
+
+    # calculate normalised aligned vectors for comparison with dipoleblock vectors
+    aligned_vectors_norm = np.linalg.norm(aligned_vectors, axis=1)
+    normalised_aligned_vectors = aligned_vectors / np.expand_dims(aligned_vectors_norm, axis=-1)
+
+    # check normalised aligned vectors match normalised dipoleblock vectors
+    assert_array_almost_equal(normalised_aligned_vectors, block.normalised_orientation_vectors)

--- a/tests/core/datablocks/test_transformblock.py
+++ b/tests/core/datablocks/test_transformblock.py
@@ -1,0 +1,39 @@
+import numpy as np
+
+from peepingtom.core import TransformBlock, DipoleBlock, PointBlock, ParticleBlock
+from tests.test_data.blocks import particleblock
+
+# test transform
+test_shifts = PointBlock(np.asarray([[0, 0, 0],
+                           [0,0, 1],
+                           [0,0,-1],
+                           [0,1, 0],
+                          [0, -1, 0],
+                          [1,0,0],
+                          [-1, 0,0 ]]))
+
+test_endpoints = PointBlock(np.zeros((test_shifts.data.shape[0], 3)))
+test_orientations = DipoleBlock(test_shifts, test_endpoints).calculate_orientation_block([0,0,1])
+
+
+def test_transformblock_instantiation():
+    # test that block instantiates properly
+    block = TransformBlock(test_shifts, test_orientations, None)
+    assert isinstance(block, TransformBlock)
+
+
+def test_transformblock_application():
+    block = TransformBlock(test_shifts, test_orientations, None)
+
+    # apply transformations in block on particles
+    new_block = block.apply_on(particleblock)
+
+    # check that object returned is ParticleBlock
+    assert isinstance(new_block, ParticleBlock)
+
+    # check that no. of new particles = number of transformations * number of particles
+    n_transforms = block.positions.data.shape[0]
+    n_particles = particleblock.positions.data.shape[0]
+    n_transformed_particles = new_block.positions.data.shape[0]
+
+    assert n_transformed_particles == n_transforms * n_particles

--- a/tests/test_data/blocks.py
+++ b/tests/test_data/blocks.py
@@ -9,11 +9,11 @@ from peepingtom.utils.helpers import linalg_helper
 # points
 n = 100
 
-x = np.random.normal(0, 10, n)
-y = np.random.normal(0, 10, n)
-v = np.random.normal(0, 50, n)
+x = np.random.normal(0, 30, n)
+y = np.random.normal(0, 30, n)
+z = np.random.normal(0, 50, n)
 
-xyz = np.column_stack([x, y, v])
+xyz = np.column_stack([x, y, z])
 
 pointblock = PointBlock(xyz)
 


### PR DESCRIPTION
This PR adds 
- a `DipoleBlock` object for simple definition of oriented particles
- a `TransformBlock` object which can store and apply 3D transformations onto existing `ParticleBlock`s

and closes #14 

It seems strange that `TransformBlock` inherits from `ParticleBlock` and has to have properties, what do you think about adding an `OrientedPointBlock` which would be a parent class to both of these?


