### PR TITLE
refactor star file reading

### DIFF
--- a/peepingtom/core/datablocks/orientationblock.py
+++ b/peepingtom/core/datablocks/orientationblock.py
@@ -10,7 +10,7 @@ class OrientationBlock(SimpleBlock):
 
     Contains factory methods for instantiation from eulerian angles
 
-    rotation_matrices : (n, 2, 2) or (n, 3, 3) array of rotation matrices R
+    data : (n, 2, 2) or (n, 3, 3) array of rotation matrices R
                         R should satisfy Rv = v' where v is a column vector
 
     """

--- a/peepingtom/io_/read/star/reader_functions.py
+++ b/peepingtom/io_/read/star/reader_functions.py
@@ -1,0 +1,33 @@
+"""This module contains various reader functions for parsing data from different types of STAR
+files.
+
+Each function should attempt to raise a ValueError quickly if it's not the right function
+for reading a given file.
+
+raw data is the dictionary produced by starfile.read()
+"""
+from .utils import rln30_df_to_particleblocks, rln31_df_to_particleblocks
+
+
+def parse_relion30_3d(raw_data):
+    """Attempt to parse raw data dict from starfile.read as a RELION 3.0 style star file
+    """
+    if len(raw_data.values()) > 1:
+        raise ValueError("Cannot parse as RELION 3.0 format STAR file")
+
+    df = list(raw_data.values)[0]
+    return rln30_df_to_particleblocks(df)
+
+
+def parse_rellon31_3d(raw_data):
+    """Attempt to parse raw data from starfile.read as a RELION 3.1 style star file
+    """
+    if list(raw_data.keys()) != ['optics', 'particles']:
+        raise ValueError("Cannot parse as RELION 3.1 format STAR file")
+
+    df = raw_data['particles'].merge(raw_data['optics'])
+    return rln31_df_to_particleblocks(df)
+
+
+reader_functions = {'relion_3.0_3d': parse_relion30_3d,
+                    'relion_3.1_3d': parse_rellon31_3d}

--- a/peepingtom/io_/read/star/star.py
+++ b/peepingtom/io_/read/star/star.py
@@ -1,82 +1,18 @@
 import starfile
-import eulerangles
 
-from ....core import ParticleBlock
-from ...utils import star_types, guess_name
+from .reader_functions import reader_functions
 
 
-def split_and_name(dataframe, split_by, basename, name_regex=None):
+def read_star(star_path):
+    """Dispatch function for reading a starfile into one or multiple ParticleBlocks
     """
-    splits a dataframe from a starfile in separate
-    """
-    if split_by in dataframe.columns:
-        groups = dataframe.groupby('rlnMicrographName')
-        return [(guess_name(subname, name_regex), dataframe) for subname, dataframe in groups]
-    else:
-        return [(guess_name(basename, name_regex), dataframe)]
+    raw_data = starfile.read(star_path, always_dict=True)
 
-
-def euler2matrix(euler_angles, convention):
-    """
-    convert euler angles to matrices
-    """
-    rotation_matrices = eulerangles.euler2matrix(euler_angles,
-                                                 axes=convention['axes'],
-                                                 intrinsic=convention['intrinsic'],
-                                                 positive_ccw=convention['positive_ccw'])
-
-    # If rotation matrices represent rotations of particle onto reference
-    # invert them so that we return matrices which transform reference onto particle
-    if convention['rotate_reference'] is False:
-        rotation_matrices = rotation_matrices.transpose((0, 2, 1))
-    return rotation_matrices
-
-
-def read_star(star_path, data_columns=[], name_regex=None, **kwargs):
-    """
-    read a starfile into one or multiple ParticleBlocks
-    data_columns: a list of column names to include as properties
-    name_regex: a regex pattern to use to guess the name of individual datasets
-    """
-    raw_dfs = starfile.read((star_path), always_dict=True)
-
-    # metadata = {}
-    dataframes = []
-    # check if relion3.1 format
-    if list(raw_dfs.keys()) == ['optics', 'particles']:
-        # TODO: use optics metadata
-        # metadata = raw_dfs['optics']
-        dataframes.append(raw_dfs['particles'])
-    else:
-        # assume every key is a different dataset (older version)
-        # TODO: make more specific
-        dataframes.extend(list(raw_dfs.values()))
-
-    # create particles
-    datablocks = []
-    for dataframe in dataframes:
-        # try every type of starfile convention
-        for star_type, params in star_types.items():
-            # check if the necessary columns exist
-            if all(colname in dataframe.columns for colname in params['coords']):
-                # split and guess names
-                named_dfs = split_and_name(dataframe, split_by=params['split_by'],
-                                           basename=star_path, name_regex=name_regex)
-                for name, df in named_dfs:
-                    # extract the data and convert it to peepingtom format
-                    raw_positions = df[params['coords']]
-                    raw_shifts = df.get(params['shifts'], 0)
-                    raw_eulers = df[params['angles']]
-                    raw_properties = df[data_columns]
-
-                    positions = (raw_positions + raw_shifts).to_numpy()
-                    orientations = euler2matrix(raw_eulers, params['angle_convention'])
-                    properties = {key: df[key].to_numpy() for key in raw_properties}
-
-                    datablocks.append(ParticleBlock(positions, orientations, properties, name=name))
-                # break of out loop if something was found
-                break
-        else:
-            raise ValueError(f'dataframe with columns {list(dataframe.columns)} could not be read')
-
-    return datablocks
+    failed_reader_functions = []
+    for style, reader_function in reader_functions.items():
+        try:
+            particle_blocks = reader_function(raw_data)
+            return particle_blocks
+        except ValueError:
+            failed_reader_functions.append((style, reader_function))
+    raise NotImplementedError(f'Failed to parse {star_path} using {failed_reader_functions}')

--- a/peepingtom/io_/read/star/star.py
+++ b/peepingtom/io_/read/star/star.py
@@ -15,4 +15,4 @@ def read_star(star_path):
             return particle_blocks
         except ValueError:
             failed_reader_functions.append((style, reader_function))
-    raise NotImplementedError(f'Failed to parse {star_path} using {failed_reader_functions}')
+    raise ValueError(f'Failed to parse {star_path} using {failed_reader_functions}')

--- a/peepingtom/io_/read/star/utils.py
+++ b/peepingtom/io_/read/star/utils.py
@@ -24,7 +24,7 @@ def rln30_df_to_particleblocks(df):
         eulers = df_[euler_headings]
         rotation_matrices = euler2matrix_rln(eulers)
 
-        properties = {key: df[key].to_numpy() for key in df.columns}
+        properties = {key: df_[key].to_numpy() for key in df.columns}
 
         particleblocks.append(ParticleBlock(xyz, rotation_matrices, properties, name=name))
 

--- a/peepingtom/io_/read/star/utils.py
+++ b/peepingtom/io_/read/star/utils.py
@@ -14,17 +14,17 @@ def rln30_df_to_particleblocks(df):
 
     particleblocks = []
 
-    for micrograph_name, df_ in df.groupby('rlnMicrographName'):
+    for micrograph_name, df_volume in df.groupby('rlnMicrographName'):
         name = Path(micrograph_name).stem
 
-        coords = df_[coord_headings]
-        shifts = df_.get(shift_headings, 0)
+        coords = df_volume[coord_headings]
+        shifts = df_volume.get(shift_headings, 0)
         xyz = (coords + shifts).to_numpy()
 
-        eulers = df_[euler_headings]
+        eulers = df_volume[euler_headings]
         rotation_matrices = euler2matrix_rln(eulers)
 
-        properties = {key: df_[key].to_numpy() for key in df.columns}
+        properties = {key: df_volume[key].to_numpy() for key in df.columns}
 
         particleblocks.append(ParticleBlock(xyz, rotation_matrices, properties, name=name))
 
@@ -41,14 +41,14 @@ def rln31_df_to_particleblocks(df):
 
     particleblocks = []
 
-    for micrograph_name, df_ in df.groupby('rlnMicrographName'):
+    for micrograph_name, df_volume in df.groupby('rlnMicrographName'):
         name = Path(micrograph_name).stem
 
-        coords = df_[coord_headings]
-        shifts_px = df_[shift_headings] / df[pixel_size_heading]
+        coords = df_volume[coord_headings]
+        shifts_px = df_volume[shift_headings] / df[pixel_size_heading]
         xyz = (coords + shifts_px).to_numpy()
 
-        eulers = df_[euler_headings]
+        eulers = df_volume[euler_headings]
         rotation_matrices = euler2matrix_rln(eulers)
 
         properties = {key: df[key].to_numpy() for key in df.columns}

--- a/peepingtom/io_/read/star/utils.py
+++ b/peepingtom/io_/read/star/utils.py
@@ -1,3 +1,10 @@
+from pathlib import Path
+
+import eulerangles
+
+from ....core import ParticleBlock
+
+
 def rln30_df_to_particleblocks(df):
     """Generate a list of ParticleBlocks from a RELION 3.0 style star file
     """
@@ -61,17 +68,6 @@ def euler2matrix_rln(euler_angles):
                                                  intrinsic=True,
                                                  positive_ccw=True)
 
-    rotation_matrices = rotation_matrices.transpose((0, 2, 1))
+    rotation_matrices = rotation_matrices.swapaxes(-2, -1)
     return rotation_matrices
-
-
-def split_and_name(dataframe, split_by, basename, name_regex=None):
-    """
-    splits a dataframe from a starfile in separate
-    """
-    if split_by in dataframe.columns:
-        groups = dataframe.groupby('rlnMicrographName')
-        return [(guess_name(subname, name_regex), dataframe) for subname, dataframe in groups]
-    else:
-        return [(guess_name(basename, name_regex), dataframe)]
 

--- a/peepingtom/io_/read/star/utils.py
+++ b/peepingtom/io_/read/star/utils.py
@@ -1,0 +1,77 @@
+def rln30_df_to_particleblocks(df):
+    """Generate a list of ParticleBlocks from a RELION 3.0 style star file
+    """
+    coord_headings = [f'rlnCoordinate{axis}' for axis in 'XYZ']
+    shift_headings = [f'rlnOrigin{axis}' for axis in 'XYZ']
+    euler_headings = [f'rlnAngle{angle}' for angle in ('Rot', 'Tilt', 'Psi')]
+
+    particleblocks = []
+
+    for micrograph_name, df_ in df.groupby('rlnMicrographName'):
+        name = Path(micrograph_name).stem
+
+        coords = df_[coord_headings]
+        shifts = df_.get(shift_headings, 0)
+        xyz = (coords + shifts).to_numpy()
+
+        eulers = df_[euler_headings]
+        rotation_matrices = euler2matrix_rln(eulers)
+
+        properties = {key: df[key].to_numpy() for key in df.columns}
+
+        particleblocks.append(ParticleBlock(xyz, rotation_matrices, properties, name=name))
+
+    return particleblocks
+
+
+def rln31_df_to_particleblocks(df):
+    """Generate a list of ParticleBlocks from a RELION 3.1 style star file dataframe
+    """
+    coord_headings = [f'rlnCoordinate{axis}' for axis in 'XYZ']
+    shift_headings = [f'rlnOrigin{axis}Angstrom' for axis in 'XYZ']
+    pixel_size_heading = 'rlnImagePixelSize'
+    euler_headings = [f'rlnAngle{angle}' for angle in ('Rot', 'Tilt', 'Psi')]
+
+    particleblocks = []
+
+    for micrograph_name, df_ in df.groupby('rlnMicrographName'):
+        name = Path(micrograph_name).stem
+
+        coords = df_[coord_headings]
+        shifts_px = df_[shift_headings] / df[pixel_size_heading]
+        xyz = (coords + shifts_px).to_numpy()
+
+        eulers = df_[euler_headings]
+        rotation_matrices = euler2matrix_rln(eulers)
+
+        properties = {key: df[key].to_numpy() for key in df.columns}
+
+        particleblocks.append(ParticleBlock(xyz, rotation_matrices, properties, name=name))
+
+    return particleblocks
+
+
+def euler2matrix_rln(euler_angles):
+    """
+    Convert (n, 3) array of RELION euler angles to rotation matrices
+    Resulting rotation matrices rotate references into particles
+    """
+    rotation_matrices = eulerangles.euler2matrix(euler_angles,
+                                                 axes='zyz',
+                                                 intrinsic=True,
+                                                 positive_ccw=True)
+
+    rotation_matrices = rotation_matrices.transpose((0, 2, 1))
+    return rotation_matrices
+
+
+def split_and_name(dataframe, split_by, basename, name_regex=None):
+    """
+    splits a dataframe from a starfile in separate
+    """
+    if split_by in dataframe.columns:
+        groups = dataframe.groupby('rlnMicrographName')
+        return [(guess_name(subname, name_regex), dataframe) for subname, dataframe in groups]
+    else:
+        return [(guess_name(basename, name_regex), dataframe)]
+


### PR DESCRIPTION
Here's an attempt at refactoring star file IO into something a little more flexible, keen to hear your thoughts

The main ideas behind this implementation are that:
- main function `read_star` reads raw data using starfile then dispatches reading
- reading is attempted by explicit "reader_functions" sequentially

I think that overall this is more explicit than the use of conventions as we were working with before which quickly becomes an unreadable nested if/else mess where interpretation is mixed with parsing. The price is a little bit of code duplication, although some refactoring could be done

relion 3.1 style shifts are now handled inline, optics and particles dataframes are merged so that shifts can be calculated properly - the implementation is robust to the possibility of multiple optics groups (which can have different pixel sizes, happens in single particle sometimes)

One thing that's lost in this implementation is the ability to use your regex wizardry for filename matching, I'm sure it can be added back in I just didn't understand it enough to do so
