### PR TITLE
peep particles together

### DIFF
--- a/peepingtom/peeper/__init__.py
+++ b/peepingtom/peeper/__init__.py
@@ -1,2 +1,3 @@
 from .depictors import Depictor, ImageDepictor, ParticleDepictor, LineDepictor, PointDepictor
 from .peeper import Peeper, peep
+from .peeper.tools import peep_particles_together

--- a/peepingtom/peeper/peeper/tools/__init__.py
+++ b/peepingtom/peeper/peeper/tools/__init__.py
@@ -1,0 +1,1 @@
+from .peep_together import peep_particles_together

--- a/peepingtom/peeper/peeper/tools/peep_together.py
+++ b/peepingtom/peeper/peeper/tools/peep_together.py
@@ -1,0 +1,27 @@
+from ....io_ import read
+from ....core import DataCrate, ParticleBlock, stack
+from ...depictors import ParticleDepictor
+from ..base import Peeper
+
+
+def peep_particles_together(*file_paths):
+    """naively read multiple files containing particle and attempt to visualise common datacrates in the same viewer
+    """
+    file_contents = [read(file_path) for file_path in file_paths]
+
+    crates = []
+
+    for idx in range(len(file_contents[0])):
+        crate = DataCrate()
+        for file in file_contents:
+            crate += file[idx]
+        crates.append(crate)
+
+
+    peeper = Peeper(crates)
+    peeper._init_viewer()
+    particlestack = stack(peeper._get_datablocks(ParticleBlock))
+    ParticleDepictor(particlestack, peeper=peeper)
+    particlestack.depictor.draw()
+    return peeper
+


### PR DESCRIPTION
Just floating some ideas because they show another case where the stacking functionality isn't really useful and that we need a better system for groups of layers :man_cartwheeling: 

This function will take multiple files and naively attempt to stack them together, with the first particleblock from each file ending up in the same datacrate - this effectively allows for visualisation of two or more files in the same viewer with their data matched across files

The stacking system unfortunately forces everything from multiple files into one particleblock upon stacking, losing any distinction between the two

In any case, the beginning of this function is useful for lining up self-similar data like refinements and plopping all the data into the same crate at the end :) 





 