### PR TITLE
check env exposed in codecov breach

### DIFF
--- a/.github/workflows/test_pr.yml
+++ b/.github/workflows/test_pr.yml
@@ -35,3 +35,6 @@ jobs:
     - name: Upload report to codecov
       run: |
         bash <(curl -s https://codecov.io/bash)
+    - name: Check env variables
+      run: |
+          env


### PR DESCRIPTION
Codecov had a [security breach](https://about.codecov.io/security-update/). They suggested to check which env variables were surfaced to the CI and to reroll anything that might be considered sensitive. At first glance here, it does not seem like any of the secret tokens (PyPI and codecov) are actually stodes as variables... I'm not sure whether that means that we're fine, or if I'm misunderstanding.