### PR TITLE
Improved default repr

### DIFF
--- a/peepingtom/datablocks/abstractblocks/datablock.py
+++ b/peepingtom/datablocks/abstractblocks/datablock.py
@@ -123,9 +123,12 @@ class DataBlock(ABC, metaclass=MetaBlock):
     def __shape_repr__(self):
         return ''
 
-    def __repr__(self):
+    def __short_repr__(self):
         return (f'{type(self).__name__}{self.__view_repr__()}'
                 f'{self.__name_repr__()}{self.__shape_repr__()}')
+
+    def __repr__(self):
+        return self.__short_repr__()
 
     def __lt__(self, other):
         if isinstance(other, type(self)):

--- a/peepingtom/datablocks/abstractblocks/simpleblock.py
+++ b/peepingtom/datablocks/abstractblocks/simpleblock.py
@@ -46,7 +46,7 @@ class SimpleBlock(DataBlock):
 
     def load(self):
         if not self._loaded and self._lazy_loader is not None:
-            logger.debug(f'loading data for lazy datablock "{self}"')
+            logger.debug(f'loading data for lazy datablock "{self.__short_repr__()}"')
             self.data = self._lazy_loader()
             self._loaded = True
 
@@ -80,3 +80,6 @@ class SimpleBlock(DataBlock):
 
     def __reversed__(self):
         yield from reversed(self.data)
+
+    def __repr__(self):
+        return f'{self.__short_repr__()}\n{self.data}'

--- a/peepingtom/peeper.py
+++ b/peepingtom/peeper.py
@@ -227,7 +227,7 @@ class Peeper:
                 vol_rep = f'{volume}({len(dbs)})'
             else:
                 vol_rep = []
-                vol_contents = [f'{db}' for db in dbs]
+                vol_contents = [f'{db.__short_repr__()}' for db in dbs]
                 if mode in ('nested_compact', 'nested') and len(vol_contents) > 7:
                     vol_contents = vol_contents[:3] + ['[...]'] + vol_contents[-3:]
                 vol_contents_repr = '\n        '.join(vol_contents)
@@ -240,7 +240,7 @@ class Peeper:
         return f'{self.__base_repr__()}:\n    {contents_rep}'
 
     def __repr__(self):
-        return self.__pretty_repr__('flat_compact')
+        return self.__pretty_repr__('nested_compact')
 
     def pprint(self, mode='full'):
         print(self.__pretty_repr__(mode))


### PR DESCRIPTION
This PR changes slightly the default representation (when `print`ed) of datablocks and peeper.

When printing a peeper, now it defaults to a more verbose mode. However, the datablocks inside use `short_repr`. When printed individually, however, datablocks will use an extended `repr`. For now, Simpleblocks print their `data`; multiblocks should implement their own representation, and for now fall back to the `short_repr`.