### PR TITLE
Particle mesh depictor

### DIFF
--- a/peepingtom/__main__.py
+++ b/peepingtom/__main__.py
@@ -8,7 +8,7 @@ import peepingtom as pt
 
 @click.command(context_settings=dict(help_option_names=['-h', '--help']))
 @click.argument('paths', nargs=-1)
-@click.option('-m', '--mode', type=click.Choice(['lone', 'zip_by_type', 'bunch']),
+@click.option('-m', '--mode', type=click.Choice(['by_name', 'zip_by_type', 'bunch']),
               help='how to arrange DataBlock into volumes [default: guess from input]')
 @click.option('-n', '--name-regex', metavar='regex',
               help=r'a regex used to infer DataBlock names from paths [fallback: \d+]')
@@ -34,7 +34,7 @@ def cli(paths, mode, name_regex, pixel_size, dry_run, strict, name, mmap, lazy):
 
     \b
     MODE choices:
-      - lone: each datablock in a separate volume
+      - by_name: each datablock in a separate volume
       - zip_by_type: one of each datablock type per volume
       - bunch: all datablocks in a single volume
 

--- a/peepingtom/datablocks/abstractblocks/_tests/test_datablock.py
+++ b/peepingtom/datablocks/abstractblocks/_tests/test_datablock.py
@@ -7,4 +7,4 @@ def test_datablock():
     db = DataBlock()
 
     with raises(ValueError):
-        db.init_depictor()
+        db.init_depictor(strict=True)

--- a/peepingtom/datablocks/abstractblocks/datablock.py
+++ b/peepingtom/datablocks/abstractblocks/datablock.py
@@ -96,9 +96,9 @@ class DataBlock(ABC, metaclass=MetaBlock):
             cp.name = new_name
         return cp
 
-    def init_depictor(self, mode='default', new_depictor=False, **kwargs):
+    def init_depictor(self, mode='default', new_depictor=False, strict=True, **kwargs):
         depictor_type = self._depiction_modes.get(mode)
-        if depictor_type is None:
+        if depictor_type is None and strict:
             raise ValueError(f'mode must be one of {tuple(self._depiction_modes.keys())}, not "{mode}"')
         if not new_depictor:
             for depictor in self.depictors:

--- a/peepingtom/datablocks/abstractblocks/datablock.py
+++ b/peepingtom/datablocks/abstractblocks/datablock.py
@@ -96,10 +96,13 @@ class DataBlock(ABC, metaclass=MetaBlock):
             cp.name = new_name
         return cp
 
-    def init_depictor(self, mode='default', new_depictor=False, strict=True, **kwargs):
+    def init_depictor(self, mode='default', new_depictor=False, strict=False, **kwargs):
         depictor_type = self._depiction_modes.get(mode)
-        if depictor_type is None and strict:
-            raise ValueError(f'mode must be one of {tuple(self._depiction_modes.keys())}, not "{mode}"')
+        if depictor_type is None:
+            if strict:
+                raise ValueError(f'mode must be one of {tuple(self._depiction_modes.keys())}, not "{mode}"')
+            else:
+                return
         if not new_depictor:
             for depictor in self.depictors:
                 if isinstance(depictor, depictor_type):

--- a/peepingtom/datablocks/multiblocks/particleblock.py
+++ b/peepingtom/datablocks/multiblocks/particleblock.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from .orientedpointblock import OrientedPointBlock
 from ..simpleblocks import PropertyBlock
-from ...depictors import ParticleDepictor
+from ...depictors import ParticlePointDepictor, ParticleMeshDepictor
 from ...utils import listify
 
 
@@ -12,7 +12,8 @@ class ParticleBlock(OrientedPointBlock):
     """
     _block_types = {'properties': PropertyBlock}
     _depiction_modes = {
-        'default': ParticleDepictor,
+        'default': ParticlePointDepictor,
+        'mesh': ParticleMeshDepictor,
     }
 
     def __init__(self, *, metadata=None, **kwargs):

--- a/peepingtom/datablocks/simpleblocks/orientationblock.py
+++ b/peepingtom/datablocks/simpleblocks/orientationblock.py
@@ -69,5 +69,10 @@ class OrientationBlock(SpatialBlock, SimpleBlock):
             all_vectors[ax] = (self.oriented_vectors(ax).sel(spatial=list(axes)))
         return all_vectors
 
+    @property
+    def zyx(self):
+        zyx = list('xyz')
+        return self.data.sel(spatial=zyx, spatial2=zyx)
+
     def __shape_repr__(self):
         return f'({self.n}, {self.ndim})'

--- a/peepingtom/depictors/__init__.py
+++ b/peepingtom/depictors/__init__.py
@@ -2,7 +2,8 @@ from .napari import (
     ImageDepictor,
     LineDepictor,
     MeshDepictor,
-    ParticleDepictor,
+    ParticlePointDepictor,
+    ParticleMeshDepictor,
     PointDepictor,
 )
 

--- a/peepingtom/depictors/napari/__init__.py
+++ b/peepingtom/depictors/napari/__init__.py
@@ -2,5 +2,5 @@ from .naparidepictor import NapariDepictor
 from .imagedepictor import ImageDepictor
 from .linedepictor import LineDepictor
 from .meshdepictor import MeshDepictor
-from .particledepictor import ParticleDepictor
+from .particledepictor import ParticleDepictor, ParticlePointDepictor, ParticleMeshDepictor
 from .pointdepictor import PointDepictor

--- a/peepingtom/depictors/napari/_tests/test_particles.py
+++ b/peepingtom/depictors/napari/_tests/test_particles.py
@@ -1,15 +1,15 @@
 import numpy as np
-from napari.layers import Vectors, Points
+from napari.layers import Vectors, Points, Surface
 
 from peepingtom.datablocks import ParticleBlock
-from peepingtom.depictors import ParticleDepictor
+from peepingtom.depictors import ParticlePointDepictor, ParticleMeshDepictor
 
 
-def test_particle_depictor():
+def test_particle_point_depictor():
     particleblock = ParticleBlock(positions_data=np.ones((2, 3)),
                                   orientations_data=np.ones((2, 3, 3)),
                                   properties_data={'a': [1, 2]})
-    particle_depictor = ParticleDepictor(particleblock)
+    particle_depictor = ParticlePointDepictor(particleblock)
     assert particle_depictor.datablock is particleblock
     assert len(particle_depictor.layers) == 0
     particle_depictor.depict()
@@ -18,3 +18,16 @@ def test_particle_depictor():
     assert all(isinstance(vec, Vectors) for vec in particle_depictor.vectors)
     particle_depictor.update()
     particle_depictor.color_by_categorical_property('a')
+
+
+def test_particle_mesh_depictor():
+    particleblock = ParticleBlock(positions_data=np.ones((2, 3)),
+                                  orientations_data=np.ones((2, 3, 3)),
+                                  properties_data={'a': [1, 2]})
+    volume = np.pad(np.ones((2, 2, 2)), 1)
+    particle_depictor = ParticleMeshDepictor(particleblock, volume=volume)
+    assert particle_depictor.datablock is particleblock
+    assert len(particle_depictor.layers) == 0
+    particle_depictor.depict()
+    assert len(particle_depictor.layers) == 1
+    assert isinstance(particle_depictor.layers[0], Surface)

--- a/peepingtom/depictors/napari/naparidepictor.py
+++ b/peepingtom/depictors/napari/naparidepictor.py
@@ -29,9 +29,10 @@ class NapariDepictor(Depictor):
         self._init_layer(layer)
 
     def _make_surface_layer(self, vertices, faces, name, values=None, **kwargs):
-        if values is None:
-            values = np.ones(vertices.shape[0])
-        data = (vertices, faces, values)
+        if values:
+            data = (vertices, faces, values)
+        else:
+            data = (vertices, faces)
         layer = Surface(data, name=name, **kwargs)
         self._init_layer(layer)
 

--- a/peepingtom/depictors/napari/particledepictor.py
+++ b/peepingtom/depictors/napari/particledepictor.py
@@ -1,11 +1,38 @@
 import numpy as np
 import xarray as xr
+from skimage.measure import marching_cubes
 
 from .naparidepictor import NapariDepictor
 from ...utils.colors import distinct_colors
 
 
 class ParticleDepictor(NapariDepictor):
+    def __init__(self, datablock):
+        super().__init__(datablock)
+        self.rescale = 1
+
+    def set_rescale(self):
+        pos = self.datablock.positions.data
+        if 0 <= pos.min().item() <= pos.max().item() <= 1:
+            peeper = self.datablock.peeper
+            if peeper and self.datablock.volume is not None:
+                same_volume = peeper.volumes[self.datablock.volume]
+                from ...datablocks import ImageBlock
+                for db in same_volume:
+                    if isinstance(db, ImageBlock):
+                        self.rescale = db.shape
+                        break
+
+    def get_positions(self, rescale=True):
+        if rescale:
+            self.set_rescale()
+        return self.datablock.positions.zyx * self.rescale * self.datablock.pixel_size
+
+
+class ParticlePointDepictor(ParticleDepictor):
+    """
+    depict particles as points and vectors
+    """
     def __init__(self, datablock):
         super().__init__(datablock)
         self.point_size = 40
@@ -18,12 +45,8 @@ class ParticleDepictor(NapariDepictor):
             y='purple',
             x='green',
         )
-        self.rescale = 1
 
-    def depict(self, rescale=True):
-        if rescale:
-            self.set_rescale()
-
+    def depict(self):
         pos = self.get_positions()
         self._make_points_layer(pos,
                                 name=f'{self.name} - particle positions',
@@ -42,9 +65,6 @@ class ParticleDepictor(NapariDepictor):
                                      edge_width=self.vector_widths[ax],
                                      )
 
-    def get_positions(self):
-        return self.datablock.positions.zyx * self.rescale * self.datablock.pixel_size
-
     def get_vectors(self):
         pos = self.get_positions()
         all_vectors = self.datablock.orientations.zyx_vectors()
@@ -53,18 +73,6 @@ class ParticleDepictor(NapariDepictor):
             vec = xr.concat([pos, vectors], 'v').transpose('n', 'v', 'spatial').values
             stacked[ax] = vec
         return stacked
-
-    def set_rescale(self):
-        pos = self.datablock.positions.data
-        if 0 <= pos.min().item() <= pos.max().item() <= 1:
-            peeper = self.datablock.peeper
-            if peeper:
-                same_volume = peeper.volumes[self.datablock.volume]
-                from ...datablocks import ImageBlock
-                for db in same_volume:
-                    if isinstance(db, ImageBlock):
-                        self.rescale = db.shape
-                        break
 
     @property
     def points(self):
@@ -88,3 +96,65 @@ class ParticleDepictor(NapariDepictor):
             vectors = self.get_vectors().values()
             for layer, vector in zip(self.vectors, vectors):
                 layer.data = vector
+
+
+class ParticleMeshDepictor(ParticleDepictor):
+    """
+    depict particles as isosurface meshes based on an input volume
+    volume: if not an ImageBlock or a xarray, axis order must be zyx
+    """
+    def __init__(self, datablock, *, volume, iso=None, step_size=1):
+        super().__init__(datablock)
+        self.volume = volume
+        self.iso = iso
+        self.step_size = step_size
+        self.mesh_color = 'cornflowerblue'
+
+    def depict(self):
+        vertices, faces = self.make_volume_mesh()
+        all_vertices, all_faces = self.tile_mesh(vertices, faces)
+
+        self._make_surface_layer(all_vertices,
+                                 all_faces,
+                                 name=f'{self.name} - particles',
+                                 scale=self.datablock.pixel_size,
+                                 # TODO: color
+                                 )
+
+    def make_volume_mesh(self):
+        vertices, faces, _, _ = marching_cubes(self.volume.copy(), level=self.iso, step_size=self.step_size)  # need copy for readonly issues
+        return vertices, faces
+
+    def tile_mesh(self, vertices, faces):
+        ori = self.datablock.orientations.data.values
+
+        # find rotated mesh vertices for each particle
+        all_vertices_rotated = (vertices @ ori)
+        # then translate them to the right place and reshape to a normal list of coords
+        pos = self.get_positions()
+        all_vertices = (all_vertices_rotated + pos.data.reshape(-1, 1, 3)).reshape(-1, 3)
+
+        # tile faces array but increment by len(vertices) every time
+        incr = np.arange(len(pos)) * len(vertices)
+        all_faces = faces.reshape(1, -1, 3) + incr.reshape(-1, 1, 1)
+        all_faces = all_faces.reshape(-1, 3)
+        return all_vertices, all_faces
+
+    @property
+    def volume(self):
+        return self._volume
+
+    @volume.setter
+    def volume(self, volume):
+        if volume.ndim != 3:
+            raise ValueError(f'volumes must have ndim=3, got {volume.ndim}')
+        if isinstance(volume, np.ndarray):
+            volume = volume
+        else:
+            from ...datablocks import ImageBlock
+            if isinstance(volume, ImageBlock):
+                volume = volume.data
+            elif isinstance(volume, xr.DataArray):
+                volume = volume
+            volume = volume.transpose('z', 'y', 'x').values
+        self._volume = volume

--- a/peepingtom/io_/reading/main.py
+++ b/peepingtom/io_/reading/main.py
@@ -97,7 +97,7 @@ def read(*globs,
     Peeper and Datablock construction arguments:
         name: the name of the Peeper (default: Peeper)
         mode: how to arrange DataBlocks into volumes. By default tries to guess.
-            - lone: each datablock in a separate volume
+            - by_name: volumes are assigned based on name
             - zip_by_type: one of each datablock type per volume
             - bunch: all datablocks in a single volume
         name_regex: a regex used to infer DataBlock names from paths. For example:
@@ -111,7 +111,7 @@ def read(*globs,
         lazy: read data lazily (if possible)
     """
     # if changing the signature of this function, change the one in `__main__.cli` as well!
-    modes = ('lone', 'zip_by_type', 'bunch')
+    modes = ('by_name', 'zip_by_type', 'bunch')
 
     if mode is not None and mode not in modes:
         raise ValueError(f'mode can only be one of {modes}')
@@ -140,11 +140,11 @@ def read(*globs,
             if len(set(count_per_type)) == 1:
                 mode = 'zip_by_type'
             else:
-                mode = 'lone'
+                mode = 'by_name'
         else:
-            mode = 'lone'
+            mode = 'by_name'
 
-    if mode == 'lone':
+    if mode == 'by_name':
         for db in datablocks:
             db.volume = db.name
     elif mode == 'bunch':

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,7 +40,7 @@ install_requires =
     xarray
     pandas
     scipy
-    skimage
+    scikit_image
     pyqtgraph
     click
     dynamotable~=0.2.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,7 @@ install_requires =
     xarray
     pandas
     scipy
+    skimage
     pyqtgraph
     click
     dynamotable~=0.2.4


### PR DESCRIPTION
This PR implements a way of depicting particles as isosurfaces meshes. Performance is quite bad for medium to high numbers of triangles, but it's a working prototype.

To use it, one needs to have a `volume` (array, xarray or ImageBlock) and pass it as such:
```python
peeper.show(mode='mesh', volume=volume, iso=0.121, step_size=7)
```