### PR TITLE
fix star pixel size

### DIFF
--- a/peepingtom/io_/reading/star.py
+++ b/peepingtom/io_/reading/star.py
@@ -18,7 +18,7 @@ shift_headings = {
 }
 
 pixel_size_headings = {
-    'RELION 3.0': ['rlnPixelSize'],
+    'RELION 3.0': ['rlnDetectorPixelSize'],
     'RELION 3.1': ['rlnImagePixelSize']
 }
 micrograph_name_heading = 'rlnMicrographName'


### PR DESCRIPTION
Star reading for relion 3.0 was using the wrong column for pixel size setting. I don't know why 2 columns exist, but in 2 different datasets this change fixed the problem.