### PR TITLE
Improve io

### DIFF
--- a/peepingtom/__main__.py
+++ b/peepingtom/__main__.py
@@ -48,6 +48,9 @@ def cli(paths, mode, name_regex, pixel_size, dry_run, strict, name, mmap, lazy):
     and name the respective DataBlocks Protein_10 and Protein_001:
         peep /path/to/dir/MyProtein* -n 'Protein_\d+'
     """  # noqa: W605
+    if not paths:
+        paths = ['./*']
+
     if dry_run:
         files = pt.io_.find_files(paths)
         print('Files found:')
@@ -61,7 +64,8 @@ def cli(paths, mode, name_regex, pixel_size, dry_run, strict, name, mmap, lazy):
                      pixel_size=pixel_size,
                      strict=strict,
                      mmap=mmap,
-                     lazy=lazy)
+                     lazy=lazy,
+                     )
 
     # set up ipython shell nicely
     banner = '''=== PeepingTom ===

--- a/peepingtom/datablocks/abstractblocks/simpleblock.py
+++ b/peepingtom/datablocks/abstractblocks/simpleblock.py
@@ -20,6 +20,11 @@ class SimpleBlock(DataBlock):
     Calling __getitem__ on a SimpleBlock will call __getitem__ on its data property and return a view
     """
     def __init__(self, *, data=None, lazy_loader=None, **kwargs):
+        """
+        data: a xarray.DataArray containing data for the datablock
+        lazy_loader: a loader function that takes the datablock as argument and
+                     loads data into it, plus any other modification
+        """
         super().__init__(**kwargs)
         if (data is None and lazy_loader is None) or \
            (data is not None and lazy_loader is not None):
@@ -47,7 +52,7 @@ class SimpleBlock(DataBlock):
     def load(self):
         if not self._loaded and self._lazy_loader is not None:
             logger.debug(f'loading data for lazy datablock "{self.__short_repr__()}"')
-            self.data = self._lazy_loader()
+            self._lazy_loader(self)
             self._loaded = True
 
     def unload(self):

--- a/peepingtom/io_/reading/mrc.py
+++ b/peepingtom/io_/reading/mrc.py
@@ -15,17 +15,17 @@ def read_mrc(image_path, name_regex=None, mmap=False, lazy=True, **kwargs):
     read an mrc file and return an ImageBlock
     """
     name = guess_name(image_path, name_regex)
-    mrc_header = mrcfile.open(image_path, header_only=True)
-    pixel_size = structured_to_unstructured(mrc_header.voxel_size)[::-1]
 
-    def loader():
+    def loader(imageblock):
         if mmap is True:
-            mrc = mrcfile.mmap(image_path).data
+            mrc = mrcfile.mmap(image_path)
         else:
-            mrc = mrcfile.open(image_path).data
-        return mrc
+            mrc = mrcfile.open(image_path)
+        imageblock.data = mrc.data
+        pixel_size = structured_to_unstructured(mrc.voxel_size)[::-1]
+        imageblock.pixel_size = pixel_size
 
-    ib = ImageBlock(lazy_loader=loader, pixel_size=pixel_size, name=name)
+    ib = ImageBlock(lazy_loader=loader, name=name)
     if not lazy:
         ib.load()
     logger.debug(f'succesfully read "{image_path}", {lazy=}, {mmap=}')


### PR DESCRIPTION
This changed `lazy_loader` from a function that returns `data`, to a function that accepts a datablocks and updates it as it pleases.

This makes it possible to have more complex behaviour and avoid having to set some thing at datablock creation. Specifically, it removes the necessity to set `pixel_size` from mrc headers on instantiation. This significanlty speeds up loading time over slow network connections (from a minute to a 3-4 secibds, with ~150 images).