### PR TITLE
Make scaling more consistent

### DIFF
--- a/peepingtom/datablocks/abstractblocks/spatialblock.py
+++ b/peepingtom/datablocks/abstractblocks/spatialblock.py
@@ -8,24 +8,29 @@ class SpatialBlock(ABC):
     provides spatial-related methods and properties
     """
     def __init__(self, *, pixel_size=1, dims_order='xyz', ndim=3, **kwargs):
-        self._pixel_size = pixel_size
         self._dims_order = dims_order
         self._ndim = ndim
         super().__init__(**kwargs)
+        # this needs to be after super, because the previous ones are needed for init, but this would break
+        # due to `parent` not existing yet and having a setter that needs it
+        self.pixel_size = pixel_size
 
     @property
     def pixel_size(self):
-        # cannot put in setter, otherwise views and children will overwrite parent
-        value = self.parent._pixel_size
-        if value is None or not np.any(value):
-            value = np.ones(self.ndim)
-        else:
-            value = np.broadcast_to(value, self.ndim)
-        return value.astype(float)
+        return self.parent._pixel_size
 
     @pixel_size.setter
     def pixel_size(self, value):
-        self._pixel_size = value
+        # cast to float first, so np.any can work
+        if isinstance(value, np.ndarray):
+            value = value.astype(float)
+        else:
+            value = float(value)
+        if not np.any(value):
+            value = np.ones(self.ndim)
+        else:
+            value = np.broadcast_to(value, self.ndim)
+        self.parent._pixel_size = value
         self.update()
 
     @property

--- a/peepingtom/depictors/napari/imagedepictor.py
+++ b/peepingtom/depictors/napari/imagedepictor.py
@@ -3,4 +3,6 @@ from .naparidepictor import NapariDepictor
 
 class ImageDepictor(NapariDepictor):
     def depict(self):
-        self._make_image_layer(self.datablock.data, name=f'{self.name} - image', scale=self.datablock.pixel_size)
+        self._make_image_layer(self.datablock.data,
+                               name=f'{self.name} - image',
+                               scale=self.datablock.pixel_size)

--- a/peepingtom/depictors/napari/naparidepictor.py
+++ b/peepingtom/depictors/napari/naparidepictor.py
@@ -16,15 +16,12 @@ class NapariDepictor(Depictor):
         layer = Image(image, name=name, scale=scale, **kwargs)
         self._init_layer(layer)
 
-    def _make_points_layer(self, points, name, scale=None, **kwargs):
-        layer = Points(points, name=name, scale=scale, n_dimensional=True, **kwargs)
+    def _make_points_layer(self, points, name, **kwargs):
+        layer = Points(points, name=name, n_dimensional=True, **kwargs)
         self._init_layer(layer)
 
-    def _make_vectors_layer(self, vectors, name, scale=None, **kwargs):
+    def _make_vectors_layer(self, vectors, name, **kwargs):
         layer = Vectors(vectors, name=name, **kwargs)
-        # TODO this is a workaround until napari #2347 is fixed
-        if scale is not None:
-            layer.scale = scale
         self._init_layer(layer)
 
     def _make_shapes_layer(self, shape, shape_type, name, **kwargs):


### PR DESCRIPTION
Before, scaling based on pixel size was handled by napari. This resulted in inconsistent behaviour, because vector lengths and widths and point sizes were being scaled as well. This meant that particles coming from data at 10A/px would result in points and vectors half as big as particles coming from data at 5A/px.

By handling scaling on our side, we avoid this problem.