### PR TITLE
updated tocs to jupyterbook 0.11

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -1,6 +1,5 @@
-# Table of content
-# Learn more at https://jupyterbook.org/customize/toc.html
-- file: index
-
+format: jb-book
+root: index
+chapters:
 - file: getting_started
 - file: tips_and_tricks

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-jupyter-book
+jupyter-book>=0.11
 sphinx_material


### PR DESCRIPTION
Jupyterbook update to 0.11, which broke the old toc format. This fixed it.