### PR TITLE
delay imports for speedup

### DIFF
--- a/peepingtom/__main__.py
+++ b/peepingtom/__main__.py
@@ -3,8 +3,6 @@ import sys
 from IPython.terminal.embed import InteractiveShellEmbed
 import click
 
-import peepingtom as pt
-
 
 @click.command(context_settings=dict(help_option_names=['-h', '--help']))
 @click.argument('paths', nargs=-1)
@@ -54,11 +52,13 @@ def cli(paths, mode, name_regex, pixel_size, dry_run, strict, name, mmap, lazy, 
         paths = ['./*']
 
     if dry_run:
-        files = pt.io_.find_files(paths)
+        from peepingtom.io_.reading.main import find_files
+        files = find_files(paths)
         print('Files found:')
         print(*(str(file) for file in files), sep='\n')
         sys.exit()
 
+    import peepingtom as pt
     peeper = pt.read(*paths,  # noqa: F841
                      name=name,
                      mode=mode,

--- a/peepingtom/depictors/napari/naparidepictor.py
+++ b/peepingtom/depictors/napari/naparidepictor.py
@@ -1,5 +1,4 @@
 import numpy as np
-from napari.layers import Points, Image, Vectors, Shapes, Surface
 
 from ..depictor import Depictor
 
@@ -13,22 +12,27 @@ class NapariDepictor(Depictor):
         self.layers = []
 
     def _make_image_layer(self, image, name, scale=None, **kwargs):
+        from napari.layers import Image
         layer = Image(image, name=name, scale=scale, **kwargs)
         self._init_layer(layer)
 
     def _make_points_layer(self, points, name, **kwargs):
+        from napari.layers import Points
         layer = Points(points, name=name, n_dimensional=True, **kwargs)
         self._init_layer(layer)
 
     def _make_vectors_layer(self, vectors, name, **kwargs):
+        from napari.layers import Vectors
         layer = Vectors(vectors, name=name, **kwargs)
         self._init_layer(layer)
 
     def _make_shapes_layer(self, shape, shape_type, name, **kwargs):
+        from napari.layers import Shapes
         layer = Shapes(shape, shape_type=shape_type, name=name, **kwargs)
         self._init_layer(layer)
 
     def _make_surface_layer(self, vertices, faces, name, values=None, **kwargs):
+        from napari.layers import Surface
         if values is None:
             values = np.ones(vertices.shape[0])
         data = (vertices, faces, values)

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ packages = find:
 python_requires = >= 3.8
 include_package_data = True
 install_requires =
-    napari[all]>=0.4.8
+    napari[all]>=0.4.9
     numpy
     pandas
     scipy


### PR DESCRIPTION
These small changes, combined with the bigger ones at https://github.com/napari/napari/pull/2662, drastically improve import speed as a module. More importantly,  something as simple as `peep -h` is now decently fast.