### PR TITLE
remove edge_width for points layer

### DIFF
--- a/src/blik/reader.py
+++ b/src/blik/reader.py
@@ -39,7 +39,6 @@ def _construct_positions_layer(
             "feature_defaults": feat_defaults,
             "face_color": "teal",
             "size": 5 / scale,
-            "border_width": 0,
             "scale": [scale] * 3,
             "shading": "spherical",
             "antialiasing": 0,
@@ -47,6 +46,7 @@ def _construct_positions_layer(
             "out_of_slice_display": True,
             **pt_kwargs,
             **({"projection_mode": "all"} if NAPARI_050 else {}),
+            **({"border_width": 0} if NAPARI_050 else {"edge_width": 0}),
         },
         "points",
     )

--- a/src/blik/reader.py
+++ b/src/blik/reader.py
@@ -39,7 +39,6 @@ def _construct_positions_layer(
             "feature_defaults": feat_defaults,
             "face_color": "teal",
             "size": 5 / scale,
-            "edge_width": 0,
             "scale": [scale] * 3,
             "shading": "spherical",
             "antialiasing": 0,

--- a/src/blik/reader.py
+++ b/src/blik/reader.py
@@ -39,6 +39,7 @@ def _construct_positions_layer(
             "feature_defaults": feat_defaults,
             "face_color": "teal",
             "size": 5 / scale,
+            "border_width": 0,
             "scale": [scale] * 3,
             "shading": "spherical",
             "antialiasing": 0,


### PR DESCRIPTION
While trying the nightly build I got the following bug when trying to open blik:

```
napari -w blik -- manual_annotation/tomo_particles_tm.star manual_annotation/tomos/*
Traceback (most recent call last):
  File "/home/marten/miniconda3/envs/blik_nightly/lib/python3.12/site-packages/napari/components/viewer_model.py", line 1471, in _add_layer_from_data
    layer = add_method(data, **(meta or {}))
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: add_points() got an unexpected keyword argument 'edge_width'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/marten/miniconda3/envs/blik_nightly/lib/python3.12/site-packages/napari/components/viewer_model.py", line 1280, in _open_or_raise_error
    added = self._add_layers_with_plugins(
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/marten/miniconda3/envs/blik_nightly/lib/python3.12/site-packages/napari/components/viewer_model.py", line 1398, in _add_layers_with_plugins
    added.extend(self._add_layer_from_data(*_data))
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/marten/miniconda3/envs/blik_nightly/lib/python3.12/site-packages/napari/components/viewer_model.py", line 1476, in _add_layer_from_data
    raise TypeError(
TypeError: _add_layer_from_data received an unexpected keyword argument ('edge_width') for layer type points

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/marten/miniconda3/envs/blik_nightly/lib/python3.12/site-packages/napari/_qt/qt_viewer.py", line 985, in _qt_open
    self.viewer.open(
  File "/home/marten/miniconda3/envs/blik_nightly/lib/python3.12/site-packages/napari/components/viewer_model.py", line 1180, in open
    layers = self._open_or_raise_error(
             ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/marten/miniconda3/envs/blik_nightly/lib/python3.12/site-packages/napari/components/viewer_model.py", line 1289, in _open_or_raise_error
    raise ReaderPluginError(
napari.errors.reader_errors.ReaderPluginError: Tried opening with blik, but failed.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/marten/miniconda3/envs/blik_nightly/bin/napari", line 8, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/marten/miniconda3/envs/blik_nightly/lib/python3.12/site-packages/napari/__main__.py", line 574, in main
    _run()
  File "/home/marten/miniconda3/envs/blik_nightly/lib/python3.12/site-packages/napari/__main__.py", line 344, in _run
    viewer._window._qt_viewer._qt_open(
  File "/home/marten/miniconda3/envs/blik_nightly/lib/python3.12/site-packages/napari/_qt/qt_viewer.py", line 993, in _qt_open
    handle_gui_reading(
  File "/home/marten/miniconda3/envs/blik_nightly/lib/python3.12/site-packages/napari/_qt/dialogs/qt_reader_dialog.py", line 190, in handle_gui_reading
    readers = prepare_remaining_readers(paths, plugin_name, error)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/marten/miniconda3/envs/blik_nightly/lib/python3.12/site-packages/napari/_qt/dialogs/qt_reader_dialog.py", line 245, in prepare_remaining_readers
    raise ReaderPluginError(
napari.errors.reader_errors.ReaderPluginError: Tried to read [manual_annotation/tomo_particles_tm.star, ...] with plugin blik, because it was associated with that file extension/because it is the only plugin capable of reading that path, but it gave an error. Try associating a different plugin or installing a different plugin for this kind of file.
```

The traceback suggested that edge_width is not an available keyword for the points layer in napari (I guess changed in latest napari?), so I made a fork and removed it. This fixes the issue for me and therefore made a pr in case you want to merge it. 

I didn't look into what changed in Napari or whether the option is fully removed or changed name.